### PR TITLE
Allow `--just-run-game` for unverified patch

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -189,20 +189,13 @@ fn main() {
             let state = LauncherState::get_from_config(|_| {})
                 .expect("Failed to get launcher state");
 
-            match state {
-                LauncherState::Launch => {
+            match (state, just_run_game) {
+                (LauncherState::Launch, _) |
+                (LauncherState::PatchNotVerified, true) |
+                (LauncherState::PredownloadAvailable { .. }, true) |
+                (LauncherState::PatchUpdateAvailable, true) => {
                     anime_launcher_sdk::star_rail::game::run().expect("Failed to run the game");
-
                     return;
-                }
-
-                LauncherState::PredownloadAvailable { .. } |
-                LauncherState::PatchUpdateAvailable => {
-                    if just_run_game {
-                        anime_launcher_sdk::star_rail::game::run().expect("Failed to run the game");
-
-                        return;
-                    }
                 }
 
                 _ => ()


### PR DESCRIPTION
The game should be runnable in the unverified patch state when `--just-run-game` is used. The state does not require immediate user action and `--just-run-game` exists specifically to allow launching in such situations where `--run-game` wouldn't.