### PR TITLE
Update flatpak-builds and RPM links

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ These packages are officially supported by the An Anime Team, and we try to ensu
 
 | Format | Wiki | Source | Distributions | Maintainer |
 | - | - | - | - | - |
-| Flatpak | [wiki](https://github.com/an-anime-team/the-honkers-railway-launcher/wiki/Installation#-any-distribution-flatpak) | [flatpak-builds](https://github.com/an-anime-team/flatpak-builds) | Any (Fedora, Pop!_OS, SteamOS / Steam Deck, etc.) | Luna (available in discord) |
-| RPM | [wiki](https://github.com/an-anime-team/the-honkers-railway-launcher/wiki/Installation#-fedora-rpm) | [THRL](https://build.opensuse.org/repositories/home:Maroxy:AAT-Apps/AAGL) * | Fedora, OpenSUSE | Maroxy (second discord admin) |
+| Flatpak | [wiki](https://github.com/an-anime-team/the-honkers-railway-launcher/wiki/Installation#-any-distribution-flatpak) | [flatpak-builds](https://github.com/an-anime-team/flatpak-builds/tree/honkers-railway) | Any (Fedora, Pop!_OS, SteamOS / Steam Deck, etc.) | Luna (available in discord) |
+| RPM | [wiki](https://github.com/an-anime-team/the-honkers-railway-launcher/wiki/Installation#-fedora-rpm) | [THRL](https://build.opensuse.org/repositories/home:Maroxy:AAT-Apps/HRL) * | Fedora, OpenSUSE | Maroxy (second discord admin) |
 
 > [!NOTE]
 > RPM packages are often really outdated. It's not recommended to use them.


### PR DESCRIPTION
Update to point to the corresponding launcher branch(es) to avoid confusion