### PR TITLE
Exclude reqwest, hyper and h2 from tracing messages

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -176,7 +176,11 @@ fn main() -> anyhow::Result<()> {
             }
         })
         .with_filter(filter_fn(move |metadata| {
-            !metadata.target().contains("rustls") && !no_verbose_tracing
+            !metadata.target().contains("rustls") &&
+            !metadata.target().contains("reqwest") &&
+            !metadata.target().contains("h2") &&
+            !metadata.target().contains("hyper_util") &&
+            !no_verbose_tracing
         }));
 
     // Prepare debug file logger
@@ -187,7 +191,10 @@ fn main() -> anyhow::Result<()> {
         .with_ansi(false)
         .with_writer(std::sync::Arc::new(file))
         .with_filter(filter_fn(|metadata| {
-            !metadata.target().contains("rustls")
+            !metadata.target().contains("rustls") &&
+            !metadata.target().contains("reqwest") &&
+            !metadata.target().contains("h2") &&
+            !metadata.target().contains("hyper_util")
         }));
 
     tracing_subscriber::registry()


### PR DESCRIPTION
oops
<img width="245" height="41" alt="изображение" src="https://github.com/user-attachments/assets/17f4f2a6-2b4e-4233-8ce2-e4307e83ecd6" />
