### PR TITLE
feat: Update predownload detection and game repair.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ glib-build-tools = "0.20"
 
 [dependencies.anime-launcher-sdk]
 git = "https://github.com/an-anime-team/anime-launcher-sdk"
-tag = "1.34.1"
+tag = "1.34.2"
 features = ["all", "star-rail", "star-rail-patch"]
 
 # path = "../anime-launcher-sdk" # ! for dev purposes only

--- a/src/ui/main/mod.rs
+++ b/src/ui/main/mod.rs
@@ -329,15 +329,23 @@ impl SimpleComponent for App {
                                                 let config = Config::get().unwrap();
                                                 let temp = config.launcher.temp.unwrap_or_else(std::env::temp_dir);
 
-                                                let mut downloaded = temp.join(game.file_name().unwrap()).metadata()
-                                                    .map(|metadata| Some(metadata.len()) >= game.downloaded_size())
-                                                    .unwrap_or(false);
+                                                // this is only going to check in `updating`
+                                                let mut downloaded = temp
+                                                    .join(format!("updating-{}", game.matching_field()
+                                                            .expect("VersionDiff is Predownload, must return Some")))
+                                                    .join(".predownloadcomplete")
+                                                    .metadata()
+                                                    .is_ok();
 
                                                 if downloaded {
                                                     for voice in voices {
-                                                        downloaded = temp.join(voice.file_name().unwrap()).metadata()
-                                                            .map(|metadata| Some(metadata.len()) >= voice.downloaded_size())
-                                                            .unwrap_or(false);
+                                                        downloaded = temp
+                                                            .join(format!("updating-{}",
+                                                                    voice.matching_field()
+                                                                    .expect("VersionDiff is Predownload, must return Some")))
+                                                            .join(".predownloadcomplete")
+                                                            .metadata()
+                                                            .is_ok();
 
                                                         if !downloaded {
                                                             break;
@@ -357,15 +365,23 @@ impl SimpleComponent for App {
                                                 let config = Config::get().unwrap();
                                                 let temp = config.launcher.temp.unwrap_or_else(std::env::temp_dir);
 
-                                                let mut downloaded = temp.join(game.file_name().unwrap()).metadata()
-                                                    .map(|metadata| Some(metadata.len()) >= game.downloaded_size())
-                                                    .unwrap_or(false);
+                                                // this is only going to check in `updating`
+                                                let mut downloaded = temp
+                                                    .join(format!("updating-{}", game.matching_field()
+                                                            .expect("VersionDiff is Predownload, must return Some")))
+                                                    .join(".predownloadcomplete")
+                                                    .metadata()
+                                                    .is_ok();
 
                                                 if downloaded {
                                                     for voice in voices {
-                                                        downloaded = temp.join(voice.file_name().unwrap()).metadata()
-                                                            .map(|metadata| Some(metadata.len()) >= voice.downloaded_size())
-                                                            .unwrap_or(false);
+                                                        downloaded = temp
+                                                            .join(format!("updating-{}",
+                                                                    voice.matching_field()
+                                                                    .expect("VersionDiff is Predownload, must return Some")))
+                                                            .join(".predownloadcomplete")
+                                                            .metadata()
+                                                            .is_ok();
 
                                                         if !downloaded {
                                                             break;
@@ -1202,6 +1218,8 @@ impl SimpleComponent for App {
 
                     std::thread::spawn(move || {
                         for mut diff in diffs {
+                            diff = diff.with_temp_folder(tmp.clone());
+
                             let result = diff.download_to(&tmp, clone!(
                                 #[strong]
                                 progress_bar_input,

--- a/src/ui/main/repair_game.rs
+++ b/src/ui/main/repair_game.rs
@@ -32,9 +32,13 @@ pub fn repair_game(
             config.launcher.edition.into()
         ).expect("failed to get game branches info");
 
-        let game_branch_info = game_branches_info.get_game_latest_by_id(
-            config.launcher.edition.api_game_id()
-        ).expect("failed to get latest game version info");
+        let latest_version = game_branches_info
+            .latest_version_by_id(config.launcher.edition.api_game_id())
+            .expect("failed to find the latest game version");
+
+        let game_branch_info = game_branches_info
+            .get_game_by_id(config.launcher.edition.api_game_id(), latest_version)
+            .expect("failed to get game version information");
 
         let downloads = sophon::installer::get_game_download_sophon_info(
             &client,


### PR DESCRIPTION
Depends on: https://github.com/an-anime-team/anime-game-core/pull/44

Related issues: https://github.com/an-anime-team/the-honkers-railway-launcher/issues/317, https://github.com/an-anime-team/the-honkers-railway-launcher/issues/318

---

Preloading:
<img width="600" height="400" alt="Screenshot_20260212_124331" src="https://github.com/user-attachments/assets/02dac47d-ea7a-4dc2-8c3a-c1151be865e0" />

Repair:
<img width="600" height="400" alt="Screenshot_20260212_135241" src="https://github.com/user-attachments/assets/2f38e84d-b986-4a1b-940c-f9f099003141" />

Normal launcher state:
<img width="600" height="400" alt="Screenshot_20260212_135532" src="https://github.com/user-attachments/assets/ed462e38-bb32-4f39-812d-7abb95df5510" />

