### PR TITLE
feat: Add launcher state/installation for mfc140, remake prefix button.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ glib-build-tools = "0.20"
 
 [dependencies.anime-launcher-sdk]
 git = "https://github.com/an-anime-team/anime-launcher-sdk"
-tag = "1.34.2"
+tag = "1.34.3"
 features = ["all", "star-rail", "star-rail-patch"]
 
 # path = "../anime-launcher-sdk" # ! for dev purposes only

--- a/assets/locales/cs/errors.ftl
+++ b/assets/locales/cs/errors.ftl
@@ -23,6 +23,7 @@ components-index-sync-failed = Nepodařilo se synchronizovat seznam komponent
 components-index-verify-failed = Nepodařilo se ověřit seznam komponent
 config-update-error = Nepodařilo se uložit konfiguraci
 wine-prefix-update-failed = Nepodařilo se aktualizovat Wine prefix
+mfc140-install-failed = Failed to install MFC140
 dxvk-install-failed = Nepodařilo se nainstalovat DXVK
 voice-package-deletion-error = Nepodařilo se odstranit Dabing
 

--- a/assets/locales/cs/general.ftl
+++ b/assets/locales/cs/general.ftl
@@ -24,6 +24,7 @@ chinese = Čínský
 migrate-installation = Přesunout instalaci
 migrate-installation-description = Otevřete speciální okno, kde můžete změnit instalační složku hry
 repair-game = Opravit hru
+remake-prefix = Remake prefix
 
 status = Stav
 

--- a/assets/locales/cs/main.ftl
+++ b/assets/locales/cs/main.ftl
@@ -61,6 +61,7 @@ apply-patch = Aplikovat patch
 disable-telemetry = Vypnout telemetrii
 download-wine = Stáhnout Wine
 create-prefix = Vytvořit Wine prefix
+install-mfc140 = Install MFC140
 update = Aktualizovat
 download = Stáhnout
 predownload-update = Předbězně stáhnout aktualizaci {$version} ({$size})

--- a/assets/locales/de/errors.ftl
+++ b/assets/locales/de/errors.ftl
@@ -23,6 +23,7 @@ components-index-sync-failed = Komponentenindex konnte nicht synchronisiert werd
 components-index-verify-failed = Komponentenindex konnte nicht verifiziert werden
 config-update-error = Speichern der Konfiguration fehlgeschlagen
 wine-prefix-update-failed = Aktualisierung des Wine-Prefix fehlgeschlagen
+mfc140-install-failed = Failed to install MFC140
 dxvk-install-failed = DXVK konnte nicht installiert werden
 voice-package-deletion-error = Sprachpaket konnte nicht gelöscht werden
 

--- a/assets/locales/de/general.ftl
+++ b/assets/locales/de/general.ftl
@@ -24,6 +24,7 @@ chinese = Chinesisch
 migrate-installation = Installation migrieren
 migrate-installation-description = Öffnet ein spezielles Fenster, in dem Sie den Installationsordner Ihres Spiels ändern können
 repair-game = Spiel Reparieren
+remake-prefix = Remake prefix
 
 status = Status
 

--- a/assets/locales/de/main.ftl
+++ b/assets/locales/de/main.ftl
@@ -61,6 +61,7 @@ apply-patch = Patch anwenden
 disable-telemetry = Blockiere Telemetrie
 download-wine = Wine Herunterladen
 create-prefix = Prefix erstellen
+install-mfc140 = Install MFC140
 update = Updaten
 download = Herunterladen
 predownload-update = Vorab-Update von Version {$version} herunterladen ({$size})

--- a/assets/locales/en/errors.ftl
+++ b/assets/locales/en/errors.ftl
@@ -23,6 +23,7 @@ components-index-sync-failed = Failed to sync components index
 components-index-verify-failed = Failed to verify components index
 config-update-error = Failed to save config
 wine-prefix-update-failed = Failed to update wine prefix
+mfc140-install-failed = Failed to install MFC140
 dxvk-install-failed = Failed to install DXVK
 voice-package-deletion-error = Failed to delete voice package
 

--- a/assets/locales/en/general.ftl
+++ b/assets/locales/en/general.ftl
@@ -24,6 +24,7 @@ chinese = Chinese
 migrate-installation = Migrate installation
 migrate-installation-description = Open special window where you can change your game installation folder
 repair-game = Repair game
+remake-prefix = Remake prefix
 
 status = Status
 

--- a/assets/locales/en/main.ftl
+++ b/assets/locales/en/main.ftl
@@ -61,6 +61,7 @@ apply-patch = Apply patch
 disable-telemetry = Disable telemetry
 download-wine = Download wine
 create-prefix = Create prefix
+install-mfc140 = Install MFC140
 install-dxvk = Install DXVK
 update = Update
 download = Download

--- a/assets/locales/es/errors.ftl
+++ b/assets/locales/es/errors.ftl
@@ -23,6 +23,7 @@ components-index-sync-failed = Fallo al sincronizar índice de componentes
 components-index-verify-failed = Fallo al verificar índice de componentes
 config-update-error = Fallo al guardar configuración
 wine-prefix-update-failed = Fallo al actualizar prefijo de Wine
+mfc140-install-failed = Failed to install MFC140
 dxvk-install-failed = Fallo al instalar DXVK
 voice-package-deletion-error = Fallo al borrar paquete de voz
 

--- a/assets/locales/es/general.ftl
+++ b/assets/locales/es/general.ftl
@@ -24,6 +24,7 @@ chinese = Chino
 migrate-installation = Migrar instalación
 migrate-installation-description = Abre una ventana especial donde puedes cambiar tu carpeta de instalación del juego
 repair-game = Reparar juego
+remake-prefix = Remake prefix
 
 status = Estado
 

--- a/assets/locales/es/main.ftl
+++ b/assets/locales/es/main.ftl
@@ -61,6 +61,7 @@ apply-patch = Aplicar parche
 disable-telemetry = Desactivar telemetría
 download-wine = Descargar wine
 create-prefix = Crear prefijo
+install-mfc140 = Install MFC140
 update = Actualizar
 download = Descargar
 predownload-update = Pre-descargar actualización {$version} ({$size})

--- a/assets/locales/fr/errors.ftl
+++ b/assets/locales/fr/errors.ftl
@@ -23,6 +23,7 @@ components-index-sync-failed = Failed to sync components index
 components-index-verify-failed = Failed to verify components index
 config-update-error = Impossible d'enregistrer la configuration
 wine-prefix-update-failed = Impossible de mettre à jour le préfix wine
+mfc140-install-failed = Failed to install MFC140
 dxvk-install-failed = Impossible d'installer DXVK
 voice-package-deletion-error = La suppression des pack de voix a échoué
 

--- a/assets/locales/fr/general.ftl
+++ b/assets/locales/fr/general.ftl
@@ -24,6 +24,7 @@ chinese = Chinois
 migrate-installation = Migrate installation
 migrate-installation-description = Open special window where you can change your game installation folder
 repair-game = Réparer le jeu
+remake-prefix = Remake prefix
 
 status = Statut
 

--- a/assets/locales/fr/main.ftl
+++ b/assets/locales/fr/main.ftl
@@ -61,6 +61,7 @@ apply-patch = Appliquer le patch
 disable-telemetry = Disable telemetry
 download-wine = Télécharger wine
 create-prefix = Créer le préfix wine
+install-mfc140 = Install MFC140
 update = Mettre à jour
 download = Télécharger
 predownload-update = Pré-télécharger la mise à jour {$version} ({$size})

--- a/assets/locales/hu/errors.ftl
+++ b/assets/locales/hu/errors.ftl
@@ -23,6 +23,7 @@ components-index-sync-failed = Failed to sync components index
 components-index-verify-failed = Failed to verify components index
 config-update-error = Sikertelen config mentés
 wine-prefix-update-failed = Sikertelen wine prefix frissítés
+mfc140-install-failed = Failed to install MFC140
 dxvk-install-failed = DXVK telepítése sikertelen
 voice-package-deletion-error = Hangcsomag törlése sikertelen
 

--- a/assets/locales/hu/general.ftl
+++ b/assets/locales/hu/general.ftl
@@ -24,6 +24,7 @@ chinese = Kínai
 migrate-installation = Játékmappa migrálása
 migrate-installation-description = Megnyit egy ablakot amivel megváltoztathatod a játékmappádat
 repair-game = Játék javítása
+remake-prefix = Remake prefix
 
 status = Státusz
 

--- a/assets/locales/hu/main.ftl
+++ b/assets/locales/hu/main.ftl
@@ -61,6 +61,7 @@ apply-patch = Patch alkalmazása
 disable-telemetry = Telemetria kikapcsolása
 download-wine = Wine letöltése
 create-prefix = Prefix létrehozása
+install-mfc140 = Install MFC140
 update = Frissítés
 download = Letöltés
 predownload-update = {$version} verzió előtöltése ({$size})

--- a/assets/locales/id/errors.ftl
+++ b/assets/locales/id/errors.ftl
@@ -23,6 +23,7 @@ components-index-sync-failed = Gagal mensinkronisasi indeks komponen
 components-index-verify-failed = Gagal memverifikasi indeks komponen
 config-update-error = Gagal menyimpan konfigurasi
 wine-prefix-update-failed = Gagal memperbarui prefix wine
+mfc140-install-failed = Failed to install MFC140
 dxvk-install-failed = Gagal memasang DXVK
 voice-package-deletion-error = Gagal menghapus berkas suara
 

--- a/assets/locales/id/general.ftl
+++ b/assets/locales/id/general.ftl
@@ -24,6 +24,7 @@ chinese = Cina
 migrate-installation = Pindahkan installasi
 migrate-installation-description = Buka menu khusus untuk mengubah direktori installasi game
 repair-game = Perbaiki game
+remake-prefix = Remake prefix
 
 status = Status
 

--- a/assets/locales/id/main.ftl
+++ b/assets/locales/id/main.ftl
@@ -68,6 +68,7 @@ apply-patch = Terapkan patch
 disable-telemetry = Nonaktifkan telemetri
 download-wine = Unduh wine
 create-prefix = Buat prefix
+install-mfc140 = Install MFC140
 update = Perbarui
 download = Unduh 
 predownload-update = Pra-unduh pembaruan versi {$version} ({$size})

--- a/assets/locales/it/errors.ftl
+++ b/assets/locales/it/errors.ftl
@@ -23,6 +23,7 @@ components-index-sync-failed = Sincronizzazione dell'indice dei componenti non r
 components-index-verify-failed = Verifica dell'indice dei componenti non riuscita
 config-update-error = Salvataggio della configurazione non riuscito
 wine-prefix-update-failed = Aggiornamento del prefisso di wine non riuscito
+mfc140-install-failed = Failed to install MFC140
 dxvk-install-failed = Installazione di DXVK non riuscita
 voice-package-deletion-error = Eliminazione del pacchetto delle voci non riuscita
 

--- a/assets/locales/it/general.ftl
+++ b/assets/locales/it/general.ftl
@@ -24,6 +24,7 @@ chinese = Cinese
 migrate-installation = Migra installazione
 migrate-installation-description = Apri una finestra speciale dove puoi cambiare la cartella di installazione del gioco
 repair-game = Ripara il gioco
+remake-prefix = Remake prefix
 
 status = Stato
 

--- a/assets/locales/it/main.ftl
+++ b/assets/locales/it/main.ftl
@@ -70,6 +70,7 @@ apply-patch = Applica patch
 disable-telemetry = Disabilita telemetria
 download-wine = Scarica wine
 create-prefix = Crea prefisso
+install-mfc140 = Install MFC140
 update = Aggiorna
 download = Scarica
 predownload-update = Prescarica {$version} aggiornamento ({$size})

--- a/assets/locales/ja/errors.ftl
+++ b/assets/locales/ja/errors.ftl
@@ -23,6 +23,7 @@ components-index-sync-failed = コンポーネントのインデックスの同�
 components-index-verify-failed = コンポーネントのインデックスの確認に失敗しました。
 config-update-error = 設定の保存に失敗しました。
 wine-prefix-update-failed = Wine のプレフィックスの更新に失敗しました。
+mfc140-install-failed = Failed to install MFC140
 dxvk-install-failed = DXVKのインストールに失敗しました。
 voice-package-deletion-error = ボイスパッケージの消去に失敗しました。
 

--- a/assets/locales/ja/general.ftl
+++ b/assets/locales/ja/general.ftl
@@ -24,6 +24,7 @@ chinese = 中国語
 migrate-installation = インストール場所を変更する。
 migrate-installation-description = ゲームのインストール先を変更できる、ウィンドウを表示します。
 repair-game = ゲームを修正する
+remake-prefix = Remake prefix
 
 status = ステータス
 

--- a/assets/locales/ja/main.ftl
+++ b/assets/locales/ja/main.ftl
@@ -69,6 +69,7 @@ apply-patch = パッチを適用する
 disable-telemetry = テレメトリを無効にする
 download-wine = ワインをダウンロード
 create-prefix = プレフィックスを作成
+install-mfc140 = Install MFC140
 update = 更新
 download = ダウンロード
 predownload-update = {$version} の早期アップデート({$size})

--- a/assets/locales/ko/errors.ftl
+++ b/assets/locales/ko/errors.ftl
@@ -23,6 +23,7 @@ components-index-sync-failed = 구성 요소 인덱스를 동기화하지 못했
 components-index-verify-failed = 컴포넌트 인덱스를 확인하지 못했습니다
 config-update-error = 구성 저장에 실패했습니다
 wine-prefix-update-failed = Wine 접두사를 업데이트하지 못했습니다
+mfc140-install-failed = Failed to install MFC140
 dxvk-install-failed = DXVK를 설치하지 못했습니다
 voice-package-deletion-error = 음성 패키지를 삭제하지 못했습니다
 

--- a/assets/locales/ko/general.ftl
+++ b/assets/locales/ko/general.ftl
@@ -24,6 +24,7 @@ chinese = 중국어
 migrate-installation = 설치 마이그레이션
 migrate-installation-description = 게임 설치 폴더를 변경할 수 있는 특수 창 열기
 repair-game = 게임 복구
+remake-prefix = Remake prefix
 
 status = 상태
 

--- a/assets/locales/ko/main.ftl
+++ b/assets/locales/ko/main.ftl
@@ -61,6 +61,7 @@ apply-patch = 패치 적용
 disable-telemetry = 원격 측정 비활성화
 download-wine = Wine 다운로드
 create-prefix = Prefix 생성
+install-mfc140 = Install MFC140
 update = 업데이트
 download = 다운로드
 predownload-update = {$version}업데이트 사전 다운로드 ({$size})

--- a/assets/locales/nl/errors.ftl
+++ b/assets/locales/nl/errors.ftl
@@ -23,6 +23,7 @@ components-index-sync-failed = Kan de componenten index niet synchroniseren
 components-index-verify-failed = Kan de componenten index niet verifiëren
 config-update-error = Kan configuratie niet opslaan
 wine-prefix-update-failed = Kan de Wine prefix niet updaten
+mfc140-install-failed = Failed to install MFC140
 dxvk-install-failed = Kan DXVK niet installeren
 voice-package-deletion-error = Kan het spraakpakket niet verwijderen
 

--- a/assets/locales/nl/general.ftl
+++ b/assets/locales/nl/general.ftl
@@ -24,6 +24,7 @@ chinese = Chinees
 migrate-installation = Migreer installatie
 migrate-installation-description = Open een venster waarin je de installatiemap het spel kunt wijzigen
 repair-game = Repareer spel
+remake-prefix = Remake prefix
 
 status = Status
 

--- a/assets/locales/nl/main.ftl
+++ b/assets/locales/nl/main.ftl
@@ -61,6 +61,7 @@ apply-patch = Pas patch toe
 disable-telemetry = Schakel telemetrie uit
 download-wine = Download Wine
 create-prefix = Creër prefix
+install-mfc140 = Install MFC140
 update = Update
 download = Download
 predownload-update = Update van {$version} ({$size}) vooraf downloaden

--- a/assets/locales/pl/errors.ftl
+++ b/assets/locales/pl/errors.ftl
@@ -23,6 +23,7 @@ components-index-sync-failed = Nie udało się zsynchronizować indeksu komponen
 components-index-verify-failed = Nie udało się zweryfikować indeksu komponentów
 config-update-error = Aktualizacja konfiguracji nie powiodła się
 wine-prefix-update-failed = Aktualizacja przedrostka Wine nie powiodła się
+mfc140-install-failed = Failed to install MFC140
 dxvk-install-failed = Instalacja DXVK nie powiodła się
 voice-package-deletion-error = Usuwanie pakietu głosowego nie powiodło się
 

--- a/assets/locales/pl/general.ftl
+++ b/assets/locales/pl/general.ftl
@@ -24,6 +24,7 @@ chinese = Chiński
 migrate-installation = Przenieś instalację
 migrate-installation-description = Otwórz specjalne okno, w którym możesz zmienić folder instalacji gry
 repair-game = Napraw grę
+remake-prefix = Remake prefix
 
 status = Status
 

--- a/assets/locales/pl/main.ftl
+++ b/assets/locales/pl/main.ftl
@@ -59,6 +59,7 @@ apply-patch = Zastosuj łatkę
 disable-telemetry = Wyłącz telemetrię
 download-wine = Pobierz Wine
 create-prefix = Utwórz przedrostek
+install-mfc140 = Install MFC140
 update = Aktualizuj
 download = Pobierz
 predownload-update = Wstępnie pobierz aktualizację {$version} ({$size})

--- a/assets/locales/pt/errors.ftl
+++ b/assets/locales/pt/errors.ftl
@@ -23,6 +23,7 @@ components-index-sync-failed = Falha ao sincronizar o índice de componentes
 components-index-verify-failed = Falha ao verificar o índice de componentes
 config-update-error = Falha ao salvar configurações
 wine-prefix-update-failed = Falha ao atualizar o prefixo wine
+mfc140-install-failed = Failed to install MFC140
 dxvk-install-failed = Falha ao instalar DXVK
 voice-package-deletion-error = Falha ao deletar o pacote de vozes
 

--- a/assets/locales/pt/general.ftl
+++ b/assets/locales/pt/general.ftl
@@ -23,6 +23,7 @@ chinese = Chinês
 migrate-installation = Migrar instalação
 migrate-installation-description = Abra janela especial onde pide mudar a pasta de instalação
 repair-game = Reparar jogo
+remake-prefix = Remake prefix
 
 status = Status
 

--- a/assets/locales/pt/main.ftl
+++ b/assets/locales/pt/main.ftl
@@ -61,6 +61,7 @@ apply-patch = Aplicar patch
 disable-telemetry = Desativar telemetria
 download-wine = Baixar wine
 create-prefix = Criar prefixo
+install-mfc140 = Install MFC140
 update = Atualizar
 download = Baixar
 predownload-update = Pre-baixar {$version} atualização ({$size})

--- a/assets/locales/ru/errors.ftl
+++ b/assets/locales/ru/errors.ftl
@@ -23,6 +23,7 @@ components-index-sync-failed = Не удалось синхронизирова�
 components-index-verify-failed = Не удалось проверить индекс компонентов
 config-update-error = Ошибка сохранения настроек
 wine-prefix-update-failed = Ошибка обновления префикса Wine
+mfc140-install-failed = Failed to install MFC140
 dxvk-install-failed = Ошибка установки DXVK
 voice-package-deletion-error = Не удалось удалить языковой пакет
 

--- a/assets/locales/ru/general.ftl
+++ b/assets/locales/ru/general.ftl
@@ -24,6 +24,7 @@ chinese = Китайский
 migrate-installation = Перенести лаунчер
 migrate-installation-description = Открыть специальное окно в котором вы сможете перенести установленную игру
 repair-game = Починить игру
+remake-prefix = Remake prefix
 
 status = Статус
 

--- a/assets/locales/ru/main.ftl
+++ b/assets/locales/ru/main.ftl
@@ -75,6 +75,7 @@ apply-patch = Применить патч
 disable-telemetry = Отключить телеметрию
 download-wine = Установить Wine
 create-prefix = Создать префикс
+install-mfc140 = Install MFC140
 update = Обновить
 download = Установить
 predownload-update = Предустановить обновление {$version} ({$size})

--- a/assets/locales/sv/errors.ftl
+++ b/assets/locales/sv/errors.ftl
@@ -23,6 +23,7 @@ components-index-sync-failed = Det gick inte att synka komponenternas index
 components-index-verify-failed = Det gick inte att verifiera komponenternas index
 config-update-error = Det gick inte att spara konfiguration
 wine-prefix-update-failed = Det gick inte att uppdatera Wine-prefix
+mfc140-install-failed = Failed to install MFC140
 dxvk-install-failed = Det gick inte att installera DXVK
 voice-package-deletion-error = Det gick inte att ta bort röstpaket
 

--- a/assets/locales/sv/general.ftl
+++ b/assets/locales/sv/general.ftl
@@ -24,6 +24,7 @@ chinese = Kinesiska
 migrate-installation = Migrera installation
 migrate-installation-description = Öppna ett speciellt fönster där du kan ändra din spelinstallationsmapp
 repair-game = Reparera spel
+remake-prefix = Remake prefix
 
 status = Status
 

--- a/assets/locales/sv/main.ftl
+++ b/assets/locales/sv/main.ftl
@@ -61,6 +61,7 @@ apply-patch = Applicera patch
 disable-telemetry = Inaktivera telemetri
 download-wine = Ladda ner Wine
 create-prefix = Skapa prefix
+install-mfc140 = Install MFC140
 update = Uppdatering
 download = Ladda ned
 predownload-update = Förnedladda {$version} uppdatering ({$size})

--- a/assets/locales/th/errors.ftl
+++ b/assets/locales/th/errors.ftl
@@ -23,6 +23,7 @@ components-index-sync-failed = ไม่สามารถซิงค์ index 
 components-index-verify-failed = ไม่สามารถตรวจสอบ index ส่วนประกอบได้
 config-update-error = บันทึกการกำหนดค่าไม่สำเร็จ
 wine-prefix-update-failed = ไม่สามารถอัปเดตการตั้งค่า Wine
+mfc140-install-failed = Failed to install MFC140
 dxvk-install-failed = ติดตั้ง DXVK ไม่สำเร็จ
 voice-package-deletion-error = ลบแพ็คเกจเสียงไม่สำเร็จ
 

--- a/assets/locales/th/general.ftl
+++ b/assets/locales/th/general.ftl
@@ -24,6 +24,7 @@ chinese = ภาษาจีน
 migrate-installation = ย้ายการติดตั้งเกม
 migrate-installation-description = เปิดหน้าต่างพิเศษที่คุณสามารถเปลี่ยนโฟลเดอร์การติดตั้งเกมของคุณได้
 repair-game = ซ่อมแซมการติดตั้งเกม
+remake-prefix = Remake prefix
 
 status = สถานะ
 

--- a/assets/locales/th/main.ftl
+++ b/assets/locales/th/main.ftl
@@ -61,6 +61,7 @@ apply-patch = ติดตั้งแพทช์
 disable-telemetry = ปิดใช้งานการวัดและส่งข้อมูล
 download-wine = ดาวน์โหลด Wine
 create-prefix = สร้างการตั้งค่า Wine
+install-mfc140 = Install MFC140
 update = อัปเดต
 download = ดาวน์โหลด
 predownload-update = ดาวน์โหลดล่วงหน้า {$version} อัปเดต ({$size})

--- a/assets/locales/tr/errors.ftl
+++ b/assets/locales/tr/errors.ftl
@@ -23,6 +23,7 @@ components-index-sync-failed = Bileşenler dizini senkronizasyonu başarısız o
 components-index-verify-failed = Bileşenler dizini doğrulanamadı
 config-update-error = Config'i kaydetme başarısız oldu
 wine-prefix-update-failed = Wine prefixini güncelleme başarısız oldu
+mfc140-install-failed = Failed to install MFC140
 dxvk-install-failed = DXVK indirilemedi
 voice-package-deletion-error = Ses dosyasını silme başarısız oldu
 

--- a/assets/locales/tr/general.ftl
+++ b/assets/locales/tr/general.ftl
@@ -24,6 +24,7 @@ chinese = Çince
 migrate-installation = Yüklemeyi aktar
 migrate-installation-description = Oyun yükleme yerinin değiştirilebileceği özel pencereyi aç
 repair-game = Oyunu tamir et
+remake-prefix = Remake prefix
 
 status = Durum
 

--- a/assets/locales/tr/main.ftl
+++ b/assets/locales/tr/main.ftl
@@ -69,6 +69,7 @@ apply-patch = Yamayı uygula
 disable-telemetry = Bilgi toplamayı devre dışı bırak
 download-wine = Wine indir
 create-prefix = Prefix oluştur
+install-mfc140 = Install MFC140
 update = Güncelle
 download = İndir
 predownload-update =  Güncellemeyi önceden indir{$version}  ({$size})

--- a/assets/locales/uk/errors.ftl
+++ b/assets/locales/uk/errors.ftl
@@ -23,6 +23,7 @@ components-index-sync-failed = Не вдалося синхронізувати 
 components-index-verify-failed = Не вдалося перевірити індекс компонентів
 config-update-error = Помилка збереження налаштувань
 wine-prefix-update-failed = Помилка оновлення префікса Wine
+mfc140-install-failed = Failed to install MFC140
 dxvk-install-failed = Помилка встановлення DXVK
 voice-package-deletion-error = Не вдалося видалити мовний пакет
 

--- a/assets/locales/uk/general.ftl
+++ b/assets/locales/uk/general.ftl
@@ -24,6 +24,7 @@ chinese = Китайська
 migrate-installation = Перенести лаунчер
 migrate-installation-description = Відкрити спеціальне вікно, в якому ви зможете перенести встановлену гру
 repair-game = Відновити гру
+remake-prefix = Remake prefix
 
 status = Статус
 

--- a/assets/locales/uk/main.ftl
+++ b/assets/locales/uk/main.ftl
@@ -72,6 +72,7 @@ apply-patch = Застосувати патч
 disable-telemetry = Вимкнути телеметрію
 download-wine = Встановити Wine
 create-prefix = Створити префікс
+install-mfc140 = Install MFC140
 update = Оновити
 download = Встановити
 predownload-update = Попередньо встановити оновлення {$version} ({$size})

--- a/assets/locales/vi/errors.ftl
+++ b/assets/locales/vi/errors.ftl
@@ -23,6 +23,7 @@ components-index-sync-failed = Không thể đồng bộ chỉ mục thành ph�
 components-index-verify-failed = Không thể xác minh chỉ mục thành phần
 config-update-error = Không thể lưu cấu hình
 wine-prefix-update-failed = Không thể cập nhật tiền tố Wine
+mfc140-install-failed = Failed to install MFC140
 dxvk-install-failed = Không thể cài đặt DXVK
 voice-package-deletion-error = Không thể xóa giọng nói
 

--- a/assets/locales/vi/general.ftl
+++ b/assets/locales/vi/general.ftl
@@ -27,6 +27,7 @@ chinese = Tiếng Trung
 migrate-installation = Di chuyển nơi cài đặt
 migrate-installation-description = Mở cửa sổ đặc biệt nơi bạn có thể thay đổi thư mục cài đặt trò chơi của mình
 repair-game = Sửa chữa
+remake-prefix = Remake prefix
 
 status = Trạng thái
 

--- a/assets/locales/vi/main.ftl
+++ b/assets/locales/vi/main.ftl
@@ -61,6 +61,7 @@ apply-patch = Áp dụng bản vá
 disable-telemetry = Vô hiệu hóa telemetry
 download-wine = Tải xuống Wine
 create-prefix = Tạo tiền tố
+install-mfc140 = Install MFC140
 update = Cập nhật
 download = Tải xuống
 predownload-update = Tải xuống trước {$version} cập nhật ({$size})

--- a/assets/locales/zh-cn/errors.ftl
+++ b/assets/locales/zh-cn/errors.ftl
@@ -23,6 +23,7 @@ components-index-sync-failed = 同步组件索引失败
 components-index-verify-failed = 验证组件索引失败
 config-update-error = 保存配置失败
 wine-prefix-update-failed = 更新 Wine Prefix 失败
+mfc140-install-failed = Failed to install MFC140
 dxvk-install-failed = 安装 DXVK 失败
 voice-package-deletion-error = 删除语音包失败
 

--- a/assets/locales/zh-cn/general.ftl
+++ b/assets/locales/zh-cn/general.ftl
@@ -24,6 +24,7 @@ chinese = 汉语
 migrate-installation = 迁移安装
 migrate-installation-description = 打开此窗口以改变游戏安装文件夹
 repair-game = 修复游戏
+remake-prefix = Remake prefix
 
 status = 状态
 

--- a/assets/locales/zh-cn/main.ftl
+++ b/assets/locales/zh-cn/main.ftl
@@ -61,6 +61,7 @@ apply-patch = 安装补丁
 disable-telemetry = 禁用监测
 download-wine = 下载 Wine
 create-prefix = 创建 Wine prefix
+install-mfc140 = Install MFC140
 update = 更新
 download = 下载
 predownload-update = 预下载版本更新 {$version} ({$size})

--- a/assets/locales/zh-tw/errors.ftl
+++ b/assets/locales/zh-tw/errors.ftl
@@ -23,6 +23,7 @@ components-index-sync-failed = 同步組件索引失敗
 components-index-verify-failed = 驗證組件索引失敗
 config-update-error = 保存配置失敗
 wine-prefix-update-failed = 更新 Wine Prefix 失敗
+mfc140-install-failed = Failed to install MFC140
 dxvk-install-failed = 安裝 DXVK 失敗
 voice-package-deletion-error = 刪除語音包失敗
 

--- a/assets/locales/zh-tw/general.ftl
+++ b/assets/locales/zh-tw/general.ftl
@@ -24,6 +24,7 @@ chinese = 漢語
 migrate-installation = 遷移安裝
 migrate-installation-description = 打開此窗口以改變遊戲安裝文件夾
 repair-game = 修復遊戲
+remake-prefix = Remake prefix
 
 status = 狀態
 

--- a/assets/locales/zh-tw/main.ftl
+++ b/assets/locales/zh-tw/main.ftl
@@ -56,6 +56,7 @@ apply-patch = 安裝補丁
 disable-telemetry = 禁用監測
 download-wine = 下載 Wine
 create-prefix = 創建 Wine prefix
+install-mfc140 = Install MFC140
 update = 更新
 download = 下載
 predownload-update = 預下載版本更新 {$version} ({$size})

--- a/src/ui/first_run/dependencies.rs
+++ b/src/ui/first_run/dependencies.rs
@@ -68,7 +68,7 @@ impl SimpleAsyncComponent for DependenciesApp {
                         },
 
                         gtk::Entry {
-                            set_text: "sudo pacman -Syu git p7zip libwebp-utils",
+                            set_text: "sudo pacman -Syu git p7zip libwebp-utils winetricks",
                             set_editable: false
                         }
                     },
@@ -85,7 +85,7 @@ impl SimpleAsyncComponent for DependenciesApp {
                         },
 
                         gtk::Entry {
-                            set_text: "sudo apt install git p7zip-full webp",
+                            set_text: "sudo apt install git p7zip-full webp winetricks",
                             set_editable: false
                         }
                     },
@@ -102,7 +102,7 @@ impl SimpleAsyncComponent for DependenciesApp {
                         },
 
                         gtk::Entry {
-                            set_text: "sudo dnf install git p7zip libwebp-tools",
+                            set_text: "sudo dnf install git p7zip libwebp-tools winetricks",
                             set_editable: false
                         }
                     },
@@ -125,6 +125,10 @@ impl SimpleAsyncComponent for DependenciesApp {
 
                             adw::ActionRow {
                                 set_title: "libwebp"
+                            },
+
+                            adw::ActionRow {
+                                set_title: "winetricks"
                             }
                         }
                     }
@@ -191,7 +195,7 @@ impl SimpleAsyncComponent for DependenciesApp {
         match msg {
             #[allow(unused_must_use)]
             DependenciesAppMsg::Continue => {
-                let packages = ["git", "dwebp"];
+                let packages = ["git", "dwebp", "winetricks"];
 
                 for package in packages {
                     if !is_available(package) {

--- a/src/ui/first_run/tos_warning.rs
+++ b/src/ui/first_run/tos_warning.rs
@@ -106,6 +106,7 @@ impl SimpleAsyncComponent for TosWarningApp {
                             let installed =
                                 is_available("git") &&
                                 is_available("dwebp") &&
+                                is_available("winetricks") &&
                                 (is_available("7z") || is_available("7za"));
 
                             if installed {

--- a/src/ui/main/install_mfc140.rs
+++ b/src/ui/main/install_mfc140.rs
@@ -1,0 +1,87 @@
+use relm4::prelude::*;
+
+use anime_launcher_sdk::wincompatlib::prelude::*;
+
+use anime_launcher_sdk::config::ConfigExt;
+use anime_launcher_sdk::star_rail::config::Config;
+
+use crate::*;
+
+use super::{App, AppMsg};
+
+pub fn install_mfc140(sender: ComponentSender<App>) {
+    let config = Config::get().unwrap();
+
+    match config.get_selected_wine() {
+        Ok(Some(wine_config)) => {
+            sender.input(AppMsg::DisableButtons(true));
+
+            std::thread::spawn(move || {
+                let wine = wine_config.to_wine(config.components.path, Some(config.game.wine.builds.join(&wine_config.name)))
+                    .with_prefix(&config.game.wine.prefix)
+                    .with_loader(WineLoader::Current);
+
+                let winetricks = Winetricks::from_wine("winetricks", &wine);
+
+                match winetricks.install_args("mfc140", ["-q", "-f"]) {
+                    Ok(mut child) => {
+                        match child.wait() {
+                            Ok(status) => {
+                                if !status.success() {
+                                    tracing::error!("Winetricks mfc140 installation failed with status: {}", status);
+
+                                    sender.input(AppMsg::Toast {
+                                        title: tr!("mfc140-install-failed"),
+                                        description: Some(format!("Exit status: {}", status))
+                                    });
+                                } else {
+                                    tracing::info!("MFC140 installed successfully");
+                                }
+                            }
+                            Err(err) => {
+                                tracing::error!("Failed to wait for winetricks process: {}", err);
+
+                                sender.input(AppMsg::Toast {
+                                    title: tr!("mfc140-install-failed"),
+                                    description: Some(err.to_string())
+                                });
+                            }
+                        }
+                    }
+                    Err(err) => {
+                        tracing::error!("Failed to start winetricks: {}", err);
+
+                        sender.input(AppMsg::Toast {
+                            title: tr!("mfc140-install-failed"),
+                            description: Some(err.to_string())
+                        });
+                    }
+                }
+
+                sender.input(AppMsg::DisableButtons(false));
+                sender.input(AppMsg::UpdateLauncherState {
+                    perform_on_download_needed: false,
+                    show_status_page: true
+                });
+            });
+        }
+
+        Ok(None) => {
+            tracing::error!("Failed to get selected wine executable");
+
+            sender.input(AppMsg::Toast {
+                title: tr!("failed-get-selected-wine"),
+                description: None
+            });
+        }
+
+        Err(err) => {
+            tracing::error!("Failed to get selected wine executable: {err}");
+
+            sender.input(AppMsg::Toast {
+                title: tr!("failed-get-selected-wine"),
+                description: Some(err.to_string())
+            });
+        }
+    }
+}

--- a/src/ui/main/mod.rs
+++ b/src/ui/main/mod.rs
@@ -9,6 +9,7 @@ mod repair_game;
 mod update_patch;
 mod download_wine;
 mod install_dxvk;
+mod install_mfc140;
 mod create_prefix;
 mod download_diff;
 mod disable_telemetry;
@@ -430,7 +431,8 @@ impl SimpleComponent for App {
                                                 Some(LauncherState::TelemetryNotDisabled) => "security-high-symbolic",
 
                                                 Some(LauncherState::WineNotInstalled) |
-                                                Some(LauncherState::PrefixNotExists) | 
+                                                Some(LauncherState::PrefixNotExists) |
+                                                Some(LauncherState::Mfc140NotInstalled) |
                                                 Some(LauncherState::DxvkNotInstalled) => "document-save-symbolic",
 
                                                 Some(LauncherState::GameUpdateAvailable(_)) |
@@ -472,6 +474,7 @@ impl SimpleComponent for App {
 
                                                 Some(LauncherState::WineNotInstalled) => tr!("download-wine"),
                                                 Some(LauncherState::PrefixNotExists)  => tr!("create-prefix"),
+                                                Some(LauncherState::Mfc140NotInstalled) => tr!("install-mfc140"),
                                                 Some(LauncherState::DxvkNotInstalled) => tr!("install-dxvk"),
 
                                                 Some(LauncherState::GameUpdateAvailable(diff)) |
@@ -1266,6 +1269,7 @@ impl SimpleComponent for App {
 
                     LauncherState::WineNotInstalled => download_wine::download_wine(sender, self.progress_bar.sender().to_owned()),
                     LauncherState::PrefixNotExists => create_prefix::create_prefix(sender),
+                    LauncherState::Mfc140NotInstalled => install_mfc140::install_mfc140(sender),
                     
                     LauncherState::DxvkNotInstalled => {
                         install_dxvk::install_dxvk(sender, self.progress_bar.sender().to_owned())

--- a/src/ui/main/mod.rs
+++ b/src/ui/main/mod.rs
@@ -91,6 +91,7 @@ pub enum AppMsg {
 
     OpenPreferences,
     RepairGame,
+    RemakePrefix,
 
     PredownloadUpdate,
     PerformAction,
@@ -1203,6 +1204,29 @@ impl SimpleComponent for App {
             }
 
             AppMsg::RepairGame => repair_game::repair_game(sender, self.progress_bar.sender().to_owned()),
+
+            AppMsg::RemakePrefix => {
+                let config = Config::get().unwrap();
+                let prefix = config.game.wine.prefix.clone();
+
+                if prefix.exists() {
+                    if let Err(err) = std::fs::remove_dir_all(&prefix) {
+                        tracing::error!("Failed to remove wine prefix: {err}");
+
+                        sender.input(AppMsg::Toast {
+                            title: tr!("wine-prefix-update-failed"),
+                            description: Some(err.to_string())
+                        });
+
+                        return;
+                    }
+                }
+
+                sender.input(AppMsg::UpdateLauncherState {
+                    perform_on_download_needed: false,
+                    show_status_page: true
+                });
+            }
 
             #[allow(unused_must_use)]
             AppMsg::PredownloadUpdate => {

--- a/src/ui/preferences/general/mod.rs
+++ b/src/ui/preferences/general/mod.rs
@@ -132,6 +132,7 @@ pub enum GeneralAppMsg {
     UpdateDownloadedDxvk,
 
     RepairGame,
+    RemakePrefix,
 
     OpenMainPage,
     OpenComponentsPage,
@@ -318,6 +319,14 @@ impl SimpleAsyncComponent for GeneralApp {
                         set_label: &tr!("repair-game"),
 
                         connect_clicked => GeneralAppMsg::RepairGame
+                    },
+
+                    gtk::Button {
+                        set_label: &tr!("remake-prefix"),
+
+                        add_css_class: "destructive-action",
+
+                        connect_clicked => GeneralAppMsg::RemakePrefix
                     }
                 }
             },
@@ -658,6 +667,10 @@ impl SimpleAsyncComponent for GeneralApp {
 
             GeneralAppMsg::RepairGame => {
                 sender.output(Self::Output::RepairGame).unwrap();
+            }
+
+            GeneralAppMsg::RemakePrefix => {
+                sender.output(Self::Output::RemakePrefix).unwrap();
             }
 
             // Don't care about it, don't want to rewrite everything.

--- a/src/ui/preferences/main.rs
+++ b/src/ui/preferences/main.rs
@@ -34,6 +34,7 @@ pub enum PreferencesAppMsg {
 
     UpdateLauncherState,
     RepairGame,
+    RemakePrefix,
 
     Toast {
         title: String,
@@ -132,6 +133,12 @@ impl SimpleAsyncComponent for PreferencesApp {
                 PREFERENCES_WINDOW.as_ref().unwrap_unchecked().close();
 
                 let _ = sender.output(Self::Output::RepairGame);
+            }
+
+            PreferencesAppMsg::RemakePrefix => unsafe {
+                PREFERENCES_WINDOW.as_ref().unwrap_unchecked().close();
+
+                let _ = sender.output(Self::Output::RemakePrefix);
             }
 
             PreferencesAppMsg::Toast { title, description } => unsafe {


### PR DESCRIPTION
Depends on: https://github.com/an-anime-team/anime-launcher-sdk/pull/33

MFC140 installation step:
<img width="600" height="400" alt="image" src="https://github.com/user-attachments/assets/67acf858-4883-4327-8726-e6446ab32f65" />
<img width="600" height="81" alt="image" src="https://github.com/user-attachments/assets/70232dae-ff2c-454e-ac15-f1884848fdb1" />

Remake prefix:
<img width="460" height="350" alt="image" src="https://github.com/user-attachments/assets/0d3dd14d-571d-490b-9b69-c16a8ce636c1" />
