### PR TITLE
Exit with error on broken symlink in place of launcher folder

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2,19 +2,14 @@ use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use relm4::prelude::*;
-
 use anime_launcher_sdk::config::ConfigExt;
 use anime_launcher_sdk::star_rail::config::{Config, Schema};
-
 use anime_launcher_sdk::star_rail::states::LauncherState;
 use anime_launcher_sdk::star_rail::consts::*;
-
 use anime_launcher_sdk::anime_game_core::prelude::*;
 use anime_launcher_sdk::anime_game_core::star_rail::prelude::*;
-
 use anime_launcher_sdk::sessions::SessionsExt;
 use anime_launcher_sdk::star_rail::sessions::Sessions;
-
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::filter::*;
 
@@ -111,7 +106,8 @@ fn main() -> anyhow::Result<()> {
 
     // Create launcher folder if it doesn't exist.
     if !LAUNCHER_FOLDER.exists() {
-        std::fs::create_dir_all(LAUNCHER_FOLDER.as_path()).expect("Failed to create launcher folder");
+        std::fs::create_dir_all(LAUNCHER_FOLDER.as_path())
+            .expect("Failed to create launcher folder");
 
         // This one is kinda critical but well, I can't do anything about it
         std::fs::write(FIRST_RUN_FILE.as_path(), "").expect("Failed to create .first-run file");
@@ -127,8 +123,7 @@ fn main() -> anyhow::Result<()> {
 
     // Create cache folder if it doesn't exist.
     if !CACHE_FOLDER.exists() {
-        std::fs::create_dir_all(CACHE_FOLDER.as_path())
-            .expect("Failed to create cache folder");
+        std::fs::create_dir_all(CACHE_FOLDER.as_path()).expect("Failed to create cache folder");
     }
 
     // Force debug output
@@ -149,9 +144,9 @@ fn main() -> anyhow::Result<()> {
     // Parse arguments
     for i in 0..args.len() {
         match args[i].as_str() {
-            "--debug"              => force_debug        = true,
-            "--run-game"           => run_game           = true,
-            "--just-run-game"      => just_run_game      = true,
+            "--debug" => force_debug = true,
+            "--run-game" => run_game = true,
+            "--just-run-game" => just_run_game = true,
             "--no-verbose-tracing" => no_verbose_tracing = true,
 
             "--session" => {
@@ -159,7 +154,7 @@ fn main() -> anyhow::Result<()> {
                 if let Some(session) = args.get(i + 1) {
                     Sessions::set_current(session.to_owned())?;
                 }
-            },
+            }
 
             arg => gtk_args.push(arg.to_string())
         }
@@ -176,11 +171,11 @@ fn main() -> anyhow::Result<()> {
             }
         })
         .with_filter(filter_fn(move |metadata| {
-            !metadata.target().contains("rustls") &&
-            !metadata.target().contains("reqwest") &&
-            !metadata.target().contains("h2") &&
-            !metadata.target().contains("hyper_util") &&
-            !no_verbose_tracing
+            !metadata.target().contains("rustls")
+                && !metadata.target().contains("reqwest")
+                && !metadata.target().contains("h2")
+                && !metadata.target().contains("hyper_util")
+                && !no_verbose_tracing
         }));
 
     // Prepare debug file logger
@@ -191,10 +186,10 @@ fn main() -> anyhow::Result<()> {
         .with_ansi(false)
         .with_writer(std::sync::Arc::new(file))
         .with_filter(filter_fn(|metadata| {
-            !metadata.target().contains("rustls") &&
-            !metadata.target().contains("reqwest") &&
-            !metadata.target().contains("h2") &&
-            !metadata.target().contains("hyper_util")
+            !metadata.target().contains("rustls")
+                && !metadata.target().contains("reqwest")
+                && !metadata.target().contains("h2")
+                && !metadata.target().contains("hyper_util")
         }));
 
     tracing_subscriber::registry()
@@ -222,7 +217,11 @@ fn main() -> anyhow::Result<()> {
     gtk::glib::set_program_name(Some("The Honkers Railway Launcher"));
 
     // Set UI language
-    let lang = CONFIG.launcher.language.parse().expect("Wrong language format used in config");
+    let lang = CONFIG
+        .launcher
+        .language
+        .parse()
+        .expect("Wrong language format used in config");
 
     i18n::set_lang(lang).expect("Failed to set launcher language");
 
@@ -231,21 +230,20 @@ fn main() -> anyhow::Result<()> {
     // Run FirstRun window if .first-run file persist
     if FIRST_RUN_FILE.exists() {
         // Create the app
-        let app = RelmApp::new(APP_ID)
-            .with_args(gtk_args);
+        let app = RelmApp::new(APP_ID).with_args(gtk_args);
 
         // Show first run window
         app.run::<FirstRunApp>(());
     }
-
     // Run the app if everything's ready
     else {
         // Temporary workaround for old patches which HAVE to be reverted
         // I don't believe to users to read announcements so better do this
-        // 
+        //
         // There's 2 files which were modified by the old patch, but since the game
-        // was updated those files were updated as well, so no need for additional actions
-        // 
+        // was updated those files were updated as well, so no need for additional
+        // actions
+        //
         // Should be removed in future
         let game_path = CONFIG.game.path.for_edition(CONFIG.launcher.edition);
 
@@ -271,9 +269,7 @@ fn main() -> anyhow::Result<()> {
             if game_path.join("UnityCrashHandler64.exe").exists() {
                 std::fs::remove_file(game_path.join("UnityCrashHandler64.exe.bak"))
                     .expect("Failed to delete 'UnityCrashHandler64.exe.bak' file");
-            }
-
-            else {
+            } else {
                 std::fs::rename(game_path.join("UnityCrashHandler64.exe.bak"), game_path.join("UnityCrashHandler64.exe"))
                     .expect("Failed to rename 'UnityCrashHandler64.exe.bak' file to 'UnityCrashHandler64.exe'");
             }
@@ -282,8 +278,8 @@ fn main() -> anyhow::Result<()> {
         // End of temporary workaround ^
 
         if run_game || just_run_game {
-            let state = LauncherState::get_from_config(|_| {})
-                .expect("Failed to get launcher state");
+            let state =
+                LauncherState::get_from_config(|_| {}).expect("Failed to get launcher state");
 
             match state {
                 LauncherState::Launch => {
@@ -292,9 +288,11 @@ fn main() -> anyhow::Result<()> {
                     return Ok(());
                 }
 
-                LauncherState::PatchNotVerified |
-                LauncherState::PredownloadAvailable { .. } |
-                LauncherState::PatchUpdateAvailable => {
+                LauncherState::PatchNotVerified
+                | LauncherState::PredownloadAvailable {
+                    ..
+                }
+                | LauncherState::PatchUpdateAvailable => {
                     if just_run_game {
                         anime_launcher_sdk::star_rail::game::run().expect("Failed to run the game");
 
@@ -307,8 +305,7 @@ fn main() -> anyhow::Result<()> {
         }
 
         // Create the app
-        let app = RelmApp::new(APP_ID)
-            .with_args(gtk_args);
+        let app = RelmApp::new(APP_ID).with_args(gtk_args);
 
         // Show main window
         app.run::<App>(());

--- a/src/main.rs
+++ b/src/main.rs
@@ -106,6 +106,15 @@ fn main() -> anyhow::Result<()> {
 
     // Create launcher folder if it doesn't exist.
     if !LAUNCHER_FOLDER.exists() {
+        // check if the location is a symlink. [Path::exists] resolves the symlink and
+        // returns whether its *target* exists or not.
+        if LAUNCHER_FOLDER.is_symlink() {
+            eprintln!(
+                "{} is a broken symlink, meaning the directory it is pointing to does not exist, cannot proceed.",
+                LAUNCHER_FOLDER.display()
+            );
+            anyhow::bail!("Launcher folder is a broken symlink");
+        }
         std::fs::create_dir_all(LAUNCHER_FOLDER.as_path())
             .expect("Failed to create launcher folder");
 
@@ -123,6 +132,13 @@ fn main() -> anyhow::Result<()> {
 
     // Create cache folder if it doesn't exist.
     if !CACHE_FOLDER.exists() {
+        if CACHE_FOLDER.is_symlink() {
+            eprintln!(
+                "{} is a broken symlink, meaning the directory it is pointing to does not exist, cannot proceed.",
+                CACHE_FOLDER.display()
+            );
+            anyhow::bail!("Cache folder is a broken symlink");
+        }
         std::fs::create_dir_all(CACHE_FOLDER.as_path()).expect("Failed to create cache folder");
     }
 


### PR DESCRIPTION
if the launcher folder or cache folder are a symlink pointing to a non-existent file/directory, print an error message to stderr and exit with an error.

Tested by making `ln -s /this/path/does/not/exist ~/.local/share/honkers-railway-launcher` and running the launcher:

```
/home/jtcf/.local/share/honkers-railway-launcher is a broken symlink, meaning the directory it is pointing to does not exist, cannot proceed.
Error: Launcher folder is a broken symlink
```