### PR TITLE
Improve repair

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,8 +57,8 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "anime-game-core"
-version = "1.38.5"
-source = "git+https://github.com/an-anime-team/anime-game-core?tag=1.38.5#894602ca63314c0648112c611c353dfdd1998e05"
+version = "1.38.8"
+source = "git+https://github.com/an-anime-team/anime-game-core?tag=1.38.8#de96f35b5a7e863f077d27abd50f6ee977cc92de"
 dependencies = [
  "anyhow",
  "bzip2 0.4.4",
@@ -83,8 +83,8 @@ dependencies = [
 
 [[package]]
 name = "anime-launcher-sdk"
-version = "1.35.7"
-source = "git+https://github.com/an-anime-team/anime-launcher-sdk?tag=1.35.7#26d92bc9533c44fd47f425ab66bab5d415eac3ad"
+version = "1.35.10"
+source = "git+https://github.com/an-anime-team/anime-launcher-sdk?tag=1.35.10#c0991afb76878f17abf754effa64d86125af8110"
 dependencies = [
  "anime-game-core",
  "anyhow",
@@ -3145,8 +3145,8 @@ dependencies = [
 
 [[package]]
 name = "sophon-lib"
-version = "0.1.5"
-source = "git+https://github.com/dawn-winery/sophon-tools.git?tag=v0.1.5#898581c4962682ab911a58ab90226095304db08a"
+version = "0.1.6"
+source = "git+https://github.com/dawn-winery/sophon-tools.git?tag=v0.1.6#89f4a70476f7e5c24f03a6c269a8b291372cfd5e"
 dependencies = [
  "bytes",
  "crossbeam-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ glib-build-tools = "0.20"
 
 [dependencies.anime-launcher-sdk]
 git = "https://github.com/an-anime-team/anime-launcher-sdk"
-tag = "1.35.7"
+tag = "1.35.10"
 features = ["all", "star-rail", "star-rail-patch"]
 
 # path = "../anime-launcher-sdk" # ! for dev purposes only

--- a/src/ui/main/repair_game.rs
+++ b/src/ui/main/repair_game.rs
@@ -1,3 +1,5 @@
+use std::sync::atomic::AtomicU64;
+
 use relm4::prelude::*;
 use relm4::Sender;
 use anime_launcher_sdk::anime_game_core::reqwest::blocking::Client;
@@ -75,6 +77,9 @@ pub fn repair_game(sender: ComponentSender<App>, progress_bar_input: Sender<Prog
                 .expect("failed to initialize sophon repairer");
             repairer.mode_repair = true;
 
+            let total_files_to_repair = AtomicU64::new(0);
+            let total_to_repair = &total_files_to_repair;
+
             let updater = |msg: SophonRepairerUpdate| match msg {
                 SophonRepairerUpdate::CheckingFilesProgress {
                     total,
@@ -86,14 +91,17 @@ pub fn repair_game(sender: ComponentSender<App>, progress_bar_input: Sender<Prog
                 }
 
                 SophonRepairerUpdate::DownloadingProgressFiles {
-                    total_files,
-                    downloaded_files
+                    downloaded_files, ..
                 } => {
-                    tracing::trace!(downloaded_files, total_files, "Repairing progress");
+                    tracing::trace!(
+                        downloaded_files,
+                        total_to_repair = total_to_repair.load(Ordering::Acquire),
+                        "Repairing progress"
+                    );
 
                     progress_bar_input.send(ProgressBarMsg::UpdateProgressCounter(
                         downloaded_files,
-                        total_files
+                        total_to_repair.load(Ordering::Acquire)
                     ));
                 }
 
@@ -104,9 +112,11 @@ pub fn repair_game(sender: ComponentSender<App>, progress_bar_input: Sender<Prog
                 }
 
                 SophonRepairerUpdate::DownloadingStarted {
-                    ..
+                    total_files, ..
                 } => {
                     tracing::trace!("Repairing started");
+
+                    total_to_repair.store(total_files, Ordering::Release);
 
                     progress_bar_input
                         .send(ProgressBarMsg::UpdateCaption(Some(tr!("repairing-files"))));


### PR DESCRIPTION
See also: [sophon-tools changes](https://dawn.wine/dawn-winery/sophon-tools/compare/v0.1.5...v0.1.6)

- Fixed repair progress reporting
- Improved it as well by having the "total" number show amount of failed files at the end of the check
- Fixed some discovered inefficiencies in download like a chunk being processed twice if a file has it twice (so N occurences of the same chunk in a file would result in an N^2 amount of writes of that chunk into a file instead of just N)

The repair progress issue was reported several times on discord before I found the cause, as well as on github: #365 